### PR TITLE
Add support for a fallback logger

### DIFF
--- a/default.go
+++ b/default.go
@@ -26,6 +26,11 @@ func SetLogLevel(level LogLevel) {
 	curDefault.SetLogLevel(level)
 }
 
+// SetFallbackLogger executes the same function on the default Base instance
+func SetFallbackLogger(logger Logger) error {
+	return curDefault.SetFallbackLogger(logger)
+}
+
 // AddLogger executes the same function on the default Base instance
 func AddLogger(logger Logger) {
 	curDefault.AddLogger(logger)

--- a/default_test.go
+++ b/default_test.go
@@ -72,6 +72,15 @@ func (s *DefaultSuite) TestDefaultShutdownLogger(t sweet.T) {
 	Expect(IsInitialized()).To(Equal(false))
 }
 
+func (s *DefaultSuite) TestSetFallbackLogger(t sweet.T) {
+	curDefault = NewBase()
+	Expect(curDefault.fallbackLogger).To(BeNil())
+
+	ml := newDefaultMemLogger()
+	SetFallbackLogger(ml)
+	Expect(curDefault.fallbackLogger).To(Equal(ml))
+}
+
 func (s *DefaultSuite) TestDefaultAddLogger(t sweet.T) {
 	curDefault = NewBase()
 	Expect(curDefault.loggers).To(HaveLen(0))

--- a/example_fallback_test.go
+++ b/example_fallback_test.go
@@ -1,0 +1,31 @@
+package gomol_test
+
+import (
+	"github.com/aphistic/gomol"
+	"github.com/aphistic/gomol-console"
+	"github.com/aphistic/gomol-json"
+)
+
+// ExampleFallbackLogger demonstrates how to use a fallback logger.
+func Example_fallbackLogger() {
+	// Create a logger that logs over TCP using JSON
+	jsonCfg := gomoljson.NewJSONLoggerConfig("tcp://192.0.2.125:4321")
+	// Continue startup even if we can't connect initially
+	jsonCfg.AllowDisconnectedInit = true
+	jsonLogger, _ := gomoljson.NewJSONLogger(jsonCfg)
+	gomol.AddLogger(jsonLogger)
+
+	// Create a logger that logs to the console
+	consoleCfg := gomolconsole.NewConsoleLoggerConfig()
+	consoleLogger, _ := gomolconsole.NewConsoleLogger(consoleCfg)
+
+	// Set the fallback logger to the console so if the
+	// TCP JSON logger is unhealthy we still get logs
+	// to stdout.
+	_ = gomol.SetFallbackLogger(consoleLogger)
+
+	gomol.InitLoggers()
+	defer gomol.ShutdownLoggers()
+
+	gomol.Debug("This is my message!")
+}

--- a/example_main_test.go
+++ b/example_main_test.go
@@ -1,0 +1,73 @@
+package gomol_test
+
+import (
+	"fmt"
+
+	"github.com/aphistic/gomol"
+	"github.com/aphistic/gomol-console"
+	"github.com/aphistic/gomol-gelf"
+)
+
+func Example() {
+	// Add a console logger
+	consoleCfg := gomolconsole.NewConsoleLoggerConfig()
+	consoleLogger, _ := gomolconsole.NewConsoleLogger(consoleCfg)
+	// Set the template to display the full message, including
+	// attributes.
+	consoleLogger.SetTemplate(gomolconsole.NewTemplateFull())
+	gomol.AddLogger(consoleLogger)
+
+	// Add a GELF logger
+	gelfCfg := gomolgelf.NewGelfLoggerConfig()
+	gelfCfg.Hostname = "localhost"
+	gelfCfg.Port = 12201
+	gelfLogger, _ := gomolgelf.NewGelfLogger(gelfCfg)
+	gomol.AddLogger(gelfLogger)
+
+	// Set some global attrs that will be added to all
+	// messages automatically
+	gomol.SetAttr("facility", "gomol.example")
+	gomol.SetAttr("another_attr", 1234)
+
+	// Configure gomol to add the filename and line number that the
+	// log was generated from, the internal sequence number to help
+	// with ordering events if your log system doesn't support a
+	// small enough sub-second resolution, and set the size of the
+	// internal queue (default is 10k messages).
+	cfg := gomol.NewConfig()
+	cfg.FilenameAttr = "filename"
+	cfg.LineNumberAttr = "line"
+	cfg.SequenceAttr = "sequence"
+	cfg.MaxQueueSize = 50000
+	gomol.SetConfig(cfg)
+
+	// Initialize the loggers
+	gomol.InitLoggers()
+	defer gomol.ShutdownLoggers()
+
+	// Create a channel on which to receive internal (asynchronous)
+	// logger errors. This is optional, but recommended in order to
+	// determine when logging may be dropping messages.
+	ch := make(chan error)
+
+	go func() {
+		// This consumer is expected to be efficient as writes to
+		// the channel are blocking. If this handler is slow, the
+		// user should add a buffer to the channel, or manually
+		// queue and batch errors for processing.
+
+		for err := range ch {
+			fmt.Printf("[Internal Error] %s\n", err.Error())
+		}
+	}()
+
+	gomol.SetErrorChan(ch)
+
+	// Log some debug messages with message-level attrs
+	// that will be sent only with that message
+	for idx := 1; idx <= 10; idx++ {
+		gomol.Dbgm(gomol.NewAttrsFromMap(map[string]interface{}{
+			"msg_attr1": 4321,
+		}), "Test message %v", idx)
+	}
+}

--- a/fallback_logger_test.go
+++ b/fallback_logger_test.go
@@ -1,0 +1,196 @@
+package gomol
+
+import (
+	"github.com/aphistic/sweet"
+	. "github.com/onsi/gomega"
+)
+
+type FallbackLoggerSuite struct{}
+
+func (s *FallbackLoggerSuite) TestSetInitialized(t sweet.T) {
+	b := NewBase()
+
+	ml := newDefaultMemLogger()
+	err := ml.InitLogger()
+	Expect(err).To(BeNil())
+	Expect(ml.IsInitialized()).To(BeTrue())
+
+	err = b.SetFallbackLogger(ml)
+	Expect(err).To(BeNil())
+
+	Expect(ml.IsInitialized()).To(BeTrue())
+}
+
+func (s *FallbackLoggerSuite) TestSetUninitialized(t sweet.T) {
+	b := NewBase()
+
+	ml := newDefaultMemLogger()
+
+	Expect(ml.IsInitialized()).ToNot(BeTrue())
+
+	err := b.SetFallbackLogger(ml)
+	Expect(err).To(BeNil())
+
+	Expect(ml.IsInitialized()).To(BeTrue())
+
+	Expect(b.fallbackLogger).To(Equal(ml))
+}
+
+func (s *FallbackLoggerSuite) TestSetUninitializedFailToInitialize(t sweet.T) {
+	b := NewBase()
+
+	ml := newDefaultMemLogger()
+	ml.config.FailInit = true
+
+	Expect(ml.IsInitialized()).ToNot(BeTrue())
+
+	err := b.SetFallbackLogger(ml)
+	Expect(err).ToNot(BeNil())
+
+	Expect(b.fallbackLogger).To(BeNil())
+}
+
+func (s *FallbackLoggerSuite) TestShutdownLoggerWhenReplacingWithNil(t sweet.T) {
+	b := NewBase()
+
+	ml := newDefaultMemLogger()
+
+	err := b.SetFallbackLogger(ml)
+	Expect(err).To(BeNil())
+	Expect(ml.IsInitialized()).To(BeTrue())
+
+	err = b.SetFallbackLogger(nil)
+	Expect(err).To(BeNil())
+	Expect(ml.IsInitialized()).ToNot(BeTrue())
+}
+
+func (s *FallbackLoggerSuite) TestShutdownLoggerWhenReplacingWithNewLogger(t sweet.T) {
+	b := NewBase()
+
+	ml := newDefaultMemLogger()
+
+	err := b.SetFallbackLogger(ml)
+	Expect(err).To(BeNil())
+	Expect(ml.IsInitialized()).To(BeTrue())
+
+	ml2 := newDefaultMemLogger()
+	err = b.SetFallbackLogger(ml2)
+	Expect(err).To(BeNil())
+	Expect(ml2.IsInitialized()).To(BeTrue())
+	Expect(ml.IsInitialized()).ToNot(BeTrue())
+}
+
+func (s *FallbackLoggerSuite) TestNoReplaceOldLoggerIfNewFailsToInitialize(t sweet.T) {
+	b := NewBase()
+
+	ml := newDefaultMemLogger()
+
+	err := b.SetFallbackLogger(ml)
+	Expect(err).To(BeNil())
+	Expect(ml.IsInitialized()).To(BeTrue())
+
+	ml2 := newDefaultMemLogger()
+	ml2.config.FailInit = true
+	err = b.SetFallbackLogger(ml2)
+	Expect(err).ToNot(BeNil())
+	Expect(ml2.IsInitialized()).ToNot(BeTrue())
+	Expect(ml.IsInitialized()).To(BeTrue())
+	Expect(b.fallbackLogger).To(Equal(ml))
+}
+
+func (s *FallbackLoggerSuite) TestLogToFallbackWithZeroLoggers(t sweet.T) {
+	b := NewBase()
+	err := b.InitLoggers()
+	Expect(err).To(BeNil())
+
+	fb := newDefaultMemLogger()
+	fb.SetHealthy(true)
+
+	err = b.SetFallbackLogger(fb)
+	Expect(err).To(BeNil())
+	Expect(fb.IsInitialized()).To(BeTrue())
+
+	b.Info("message 1")
+	b.Flush()
+
+	Expect(fb.Messages()).To(HaveLen(1))
+}
+
+func (s *FallbackLoggerSuite) TestLogToFallbackOnUnhealthy(t sweet.T) {
+	b := NewBase()
+	ml := newDefaultMemLogger()
+	ml.SetHealthy(true)
+	err := b.AddLogger(ml)
+	Expect(err).To(BeNil())
+	err = b.InitLoggers()
+	Expect(err).To(BeNil())
+
+	fb := newDefaultMemLogger()
+	fb.SetHealthy(true)
+	err = b.SetFallbackLogger(fb)
+	Expect(err).To(BeNil())
+
+	b.Info("message 1")
+	b.Flush()
+
+	Expect(ml.Messages()).To(HaveLen(1))
+	Expect(fb.Messages()).To(HaveLen(0))
+
+	ml.SetHealthy(false)
+
+	b.Info("message 2")
+	b.Flush()
+
+	Expect(ml.Messages()).To(HaveLen(2))
+	Expect(fb.Messages()).To(HaveLen(1))
+
+	ml.SetHealthy(true)
+
+	b.Info("message 3")
+	b.Flush()
+
+	Expect(ml.Messages()).To(HaveLen(3))
+	Expect(fb.Messages()).To(HaveLen(1))
+}
+
+func (s *FallbackLoggerSuite) TestLogToFallbackMultipleUnhealthy(t sweet.T) {
+	b := NewBase()
+	ml1 := newDefaultMemLogger() // Starts unhealthy
+	ml2 := newDefaultMemLogger() // Starts unhealthy
+	err := b.AddLogger(ml1)
+	Expect(err).To(BeNil())
+	err = b.AddLogger(ml2)
+	Expect(err).To(BeNil())
+	err = b.InitLoggers()
+	Expect(err).To(BeNil())
+
+	fb := newDefaultMemLogger()
+	fb.SetHealthy(true)
+	err = b.SetFallbackLogger(fb)
+	Expect(err).To(BeNil())
+
+	b.Info("message 1")
+	b.Flush()
+
+	Expect(ml1.Messages()).To(HaveLen(1))
+	Expect(ml2.Messages()).To(HaveLen(1))
+	Expect(fb.Messages()).To(HaveLen(1))
+
+	ml1.SetHealthy(true)
+
+	b.Info("message 2")
+	b.Flush()
+
+	Expect(ml1.Messages()).To(HaveLen(2))
+	Expect(ml2.Messages()).To(HaveLen(2))
+	Expect(fb.Messages()).To(HaveLen(2))
+
+	ml2.SetHealthy(true)
+
+	b.Info("message 3")
+	b.Flush()
+
+	Expect(ml1.Messages()).To(HaveLen(3))
+	Expect(ml2.Messages()).To(HaveLen(3))
+	Expect(fb.Messages()).To(HaveLen(2))
+}

--- a/gomol_test.go
+++ b/gomol_test.go
@@ -15,13 +15,15 @@ func TestMain(m *testing.M) {
 	sweet.Run(m, func(s *sweet.S) {
 		s.RegisterPlugin(junit.NewPlugin())
 
-		s.AddSuite(&GomolSuite{})
 		s.AddSuite(&AttrsSuite{})
 		s.AddSuite(&BaseSuite{})
 		s.AddSuite(&DefaultSuite{})
-		s.AddSuite(&LogAdapterSuite{})
+		s.AddSuite(&FallbackLoggerSuite{})
+		s.AddSuite(&GomolSuite{})
 		s.AddSuite(&IssueSuite{})
+		s.AddSuite(&LogAdapterSuite{})
 		s.AddSuite(&LogLevelSuite{})
+		s.AddSuite(&MemLoggerSuite{})
 	})
 }
 

--- a/logger.go
+++ b/logger.go
@@ -2,18 +2,25 @@ package gomol
 
 import "time"
 
-/*
-Logger is an interface libraries can implement to create their own loggers to be
-used with gomol.
-*/
+// Logger is an interface libraries can implement to create their own loggers to be
+// used with gomol.
 type Logger interface {
 	SetBase(*Base)
 
 	InitLogger() error
 	ShutdownLogger() error
-	IsInitialized() bool
+	IsInitialized() bool // TODO This should be named Initialized()
 
 	Logm(time.Time, LogLevel, map[string]interface{}, string) error
+}
+
+// HealthCheckLogger is an interface a Logger can implement to provide hinting at
+// whether it is healthy or not.  If a Logger does not implement HealthCheckLogger
+// it is always assumed to be healthy.
+type HealthCheckLogger interface {
+	Logger
+
+	Healthy() bool
 }
 
 // HookPreQueue is an interface a Logger can implement to be able to inspect

--- a/mem_logger.go
+++ b/mem_logger.go
@@ -24,11 +24,15 @@ type memLogger struct {
 	messageLock sync.Mutex
 	messages    []*memMessage
 
+	healthy       bool
 	isInitialized bool
 	isShutdown    bool
 
 	tpl *template.Template
 }
+
+var _ Logger = &memLogger{}
+var _ HealthCheckLogger = &memLogger{}
 
 type memMessage struct {
 	Timestamp   time.Time
@@ -86,6 +90,14 @@ func (l *memLogger) ShutdownLogger() error {
 	l.isInitialized = false
 	l.isShutdown = true
 	return nil
+}
+
+func (l *memLogger) Healthy() bool {
+	return l.healthy
+}
+
+func (l *memLogger) SetHealthy(healthy bool) {
+	l.healthy = healthy
 }
 
 func (l *memLogger) Logm(timestamp time.Time, level LogLevel, m map[string]interface{}, msg string) error {

--- a/mem_logger_test.go
+++ b/mem_logger_test.go
@@ -13,14 +13,16 @@ func newDefaultMemLogger() *memLogger {
 	return l
 }
 
-func (s *GomolSuite) TestMemInitLogger(t sweet.T) {
+type MemLoggerSuite struct{}
+
+func (s *MemLoggerSuite) TestMemInitLogger(t sweet.T) {
 	ml := newDefaultMemLogger()
 	Expect(ml.IsInitialized()).To(Equal(false))
 	ml.InitLogger()
 	Expect(ml.IsInitialized()).To(Equal(true))
 }
 
-func (s *GomolSuite) TestMemInitLoggerFail(t sweet.T) {
+func (s *MemLoggerSuite) TestMemInitLoggerFail(t sweet.T) {
 	mlCfg := newMemLoggerConfig()
 	mlCfg.FailInit = true
 	ml, err := newMemLogger(mlCfg)
@@ -32,14 +34,14 @@ func (s *GomolSuite) TestMemInitLoggerFail(t sweet.T) {
 	Expect(err.Error()).To(Equal("Init failed"))
 }
 
-func (s *GomolSuite) TestMemShutdownLogger(t sweet.T) {
+func (s *MemLoggerSuite) TestMemShutdownLogger(t sweet.T) {
 	ml := newDefaultMemLogger()
 	Expect(ml.isShutdown).To(Equal(false))
 	ml.ShutdownLogger()
 	Expect(ml.isShutdown).To(Equal(true))
 }
 
-func (s *GomolSuite) TestMemShutdownLoggerFail(t sweet.T) {
+func (s *MemLoggerSuite) TestMemShutdownLoggerFail(t sweet.T) {
 	mlCfg := newMemLoggerConfig()
 	mlCfg.FailShutdown = true
 	ml, err := newMemLogger(mlCfg)
@@ -51,7 +53,7 @@ func (s *GomolSuite) TestMemShutdownLoggerFail(t sweet.T) {
 	Expect(err.Error()).To(Equal("Shutdown failed"))
 }
 
-func (s *GomolSuite) TestMemClearMessages(t sweet.T) {
+func (s *MemLoggerSuite) TestMemClearMessages(t sweet.T) {
 	ml := newDefaultMemLogger()
 	Expect(ml.Messages()).To(HaveLen(0))
 	ml.Logm(time.Now(), LevelDebug, nil, "test")
@@ -60,7 +62,7 @@ func (s *GomolSuite) TestMemClearMessages(t sweet.T) {
 	Expect(ml.Messages()).To(HaveLen(0))
 }
 
-func (s *GomolSuite) TestMemLogmNoAttrs(t sweet.T) {
+func (s *MemLoggerSuite) TestMemLogmNoAttrs(t sweet.T) {
 	ml := newDefaultMemLogger()
 	ml.Logm(time.Now(), LevelDebug, nil, "test")
 
@@ -71,7 +73,7 @@ func (s *GomolSuite) TestMemLogmNoAttrs(t sweet.T) {
 	Expect(msg.Attrs).To(HaveLen(0))
 }
 
-func (s *GomolSuite) TestMemLogmAttrs(t sweet.T) {
+func (s *MemLoggerSuite) TestMemLogmAttrs(t sweet.T) {
 	ts := time.Unix(10, 0)
 	ml := newDefaultMemLogger()
 	ml.Logm(
@@ -89,7 +91,7 @@ func (s *GomolSuite) TestMemLogmAttrs(t sweet.T) {
 	Expect(msg.Attrs["attr1"]).To(Equal(4321))
 }
 
-func (s *GomolSuite) TestMemBaseAttrs(t sweet.T) {
+func (s *MemLoggerSuite) TestMemBaseAttrs(t sweet.T) {
 	ts := time.Unix(10, 0)
 
 	b := NewBase()
@@ -118,7 +120,7 @@ func (s *GomolSuite) TestMemBaseAttrs(t sweet.T) {
 	Expect(msg.Attrs["attr3"]).To(Equal("val3"))
 }
 
-func (s *GomolSuite) TestMemStringAttrs(t sweet.T) {
+func (s *MemLoggerSuite) TestMemStringAttrs(t sweet.T) {
 	ts := time.Unix(10, 0)
 
 	b := NewBase()
@@ -149,4 +151,18 @@ func (s *GomolSuite) TestMemStringAttrs(t sweet.T) {
 	Expect(msg.StringAttrs["attr1"]).To(Equal("4321"))
 	Expect(msg.StringAttrs["attr2"]).To(Equal("val2"))
 	Expect(msg.StringAttrs["attr3"]).To(Equal("val3"))
+}
+
+func (s *MemLoggerSuite) TestHealthy(t sweet.T) {
+	ml := newDefaultMemLogger()
+
+	Expect(ml.Healthy()).To(BeFalse())
+
+	ml.SetHealthy(true)
+
+	Expect(ml.Healthy()).To(BeTrue())
+
+	ml.SetHealthy(false)
+
+	Expect(ml.Healthy()).To(BeFalse())
 }


### PR DESCRIPTION
Adds a fallback logger that will be logged to if any of the primary loggers go unhealthy.  This is to avoid a situation where you don't want to log to something most of the time (console, for example) but you do when your primary logger is unavailable (such as a network partition).